### PR TITLE
feat: Add genotype filtering for regions

### DIFF
--- a/src/proletract/modules/io/__init__.py
+++ b/src/proletract/modules/io/__init__.py
@@ -1,0 +1,5 @@
+"""
+IO modules for ProleTRact.
+"""
+# This file makes the io module a package
+


### PR DESCRIPTION
<h2> Add Genotype Filtering Feature</h2>

<p>This Merge adds genotype filtering functionality to ProleTRact, allowing users to filter tandem repeat regions by genotype in both individual and cohort modes.</p>

<h3>Features</h3>
<ul>
  <li><strong>Genotype Extraction:</strong> Extracts genotype information (GT field) from VCF records during parsing</li>
  <li><strong>Filter UI:</strong> Added sidebar filter in both Individual and Cohort modes to select genotypes to display</li>
</ul>


<h3> User Experience</h3>
<ul>
  <li>Users can now filter regions by genotype using a multi-select dropdown in the sidebar</li>
  <li>Filtering works seamlessly with existing search and navigation functionality</li>
  <li>Visual feedback shows how many regions match the selected genotypes</li>
</ul>



